### PR TITLE
[server, pkg] early exit on dpkg postscript if upgrading

### DIFF
--- a/tesseract-server/pkg/deb/maintainer-scripts/postinst
+++ b/tesseract-server/pkg/deb/maintainer-scripts/postinst
@@ -12,6 +12,12 @@ echo "# Creating user 'tesseract-olap' if needed"
 
 id -u tesseract-olap >/dev/null 2>&1 || useradd tesseract-olap
 
+read -p "Are you upgrading, and would like to keep your old .service file? y/n: " -r
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    exit 0
+fi
+
 read -p "Would you like to use the default db address 127.0.0.1:9000? y/n: " -r
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then


### PR DESCRIPTION
Had some questions about the best way to handle this, so let me know what you think.

Basically, I just need to be able to upgrade without changing the .service file.

on the post install, I'm just skipping all the customizing of the file.
And for copying of the .service in the firs place, it should be blocked by https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles