### PR TITLE
[server] LL duplicate names error message

### DIFF
--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -138,7 +138,7 @@ impl Schema {
         self.into()
     }
 
-    pub fn has_unique_levels_properties(&self) -> bool {
+    pub fn has_unique_levels_properties(&self) -> CubeHasUniqueLevelsAndProperties {
         for cube in &self.cubes {
             let mut levels = HashSet::new();
             let mut properties = HashSet::new();
@@ -153,7 +153,10 @@ impl Schema {
                                 "Found repeated level name: {}.{}.{}.{}",
                                 cube.name, dimension.name, hierarchy.name, level.name
                             );
-                            return false
+                            return CubeHasUniqueLevelsAndProperties::False {
+                                cube: cube.name.clone(),
+                                name: level.name.clone(),
+                            };
                         }
 
                         if let Some(ref props) = level.properties {
@@ -163,7 +166,10 @@ impl Schema {
                                         "Found repeated property name: {}.{}.{}.{}.{}",
                                         cube.name, dimension.name, hierarchy.name, level.name, property.name
                                     );
-                                    return false
+                                    return CubeHasUniqueLevelsAndProperties::False {
+                                        cube: cube.name.clone(),
+                                        name: property.name.clone(),
+                                    };
                                 }
                             }
                         }
@@ -172,7 +178,7 @@ impl Schema {
             }
         }
 
-        true
+        CubeHasUniqueLevelsAndProperties::True
     }
 
     pub fn members_sql(
@@ -1238,6 +1244,16 @@ struct MembersQueryIR {
     table_sql: String,
     key_column: String,
     name_column: Option<String>,
+}
+
+
+#[derive(Debug, Clone)]
+pub enum CubeHasUniqueLevelsAndProperties {
+    True,
+    False {
+        cube: String,
+        name: String,
+    }
 }
 
 #[cfg(test)]

--- a/tesseract-server/src/errors.rs
+++ b/tesseract-server/src/errors.rs
@@ -10,12 +10,24 @@ pub enum ServerError {
     Db {
         cause: String,
     },
+    #[fail(display="Logic Layer duplicate name: {:?} in cube {:?}. Level/property name must be unique.", name, cube)]
+    LogicLayerDuplicateNames {
+        cube: String,
+        name: String,
+    },
+
+    #[fail(display="Internal Server Error {}", code)]
+    ErrorCode {
+        code: String,
+    }
 }
 
 impl actix_web::error::ResponseError for ServerError {
     fn error_response(&self) -> HttpResponse {
         match self {
             ServerError::Db { cause } => HttpResponse::InternalServerError().body(cause.clone()),
+            ServerError::LogicLayerDuplicateNames { .. } => HttpResponse::InternalServerError().body(self.to_string()),
+            ServerError::ErrorCode { .. } => HttpResponse::InternalServerError().body(self.to_string()),
         }
     }
 }

--- a/tesseract-server/src/errors.rs
+++ b/tesseract-server/src/errors.rs
@@ -10,6 +10,11 @@ pub enum ServerError {
     Db {
         cause: String,
     },
+    // TODO route this through Error in handler, so that it will log. Right now, nothing gets
+    // logged because it's just a httpresponse in the logic layer non-unique handler
+    // In addition, even if there's and ErrorCode variant, it should still be able to log a cause,
+    // as is currently done on Db failures, but without hardcoding the error value into the handler
+    // because that should be handled here in the error module.
     #[fail(display="Logic Layer duplicate name: {:?} in cube {:?}. Level/property name must be unique.", name, cube)]
     LogicLayerDuplicateNames {
         cube: String,

--- a/tesseract-server/src/handlers/logic_layer/mod.rs
+++ b/tesseract-server/src/handlers/logic_layer/mod.rs
@@ -10,21 +10,41 @@ pub use self::geoservice::query_geoservice;
 pub use self::metadata::logic_layer_members_handler;
 pub use self::metadata::logic_layer_members_default_handler;
 
-use actix_web::{HttpRequest, HttpResponse, Path};
+use actix_web::{HttpRequest, HttpResponse, Path, ResponseError};
 use crate::app::AppState;
+use crate::errors::ServerError;
+use tesseract_core::CubeHasUniqueLevelsAndProperties;
 
 
 pub fn logic_layer_non_unique_levels_default_handler(
-    (_req, _cube): (HttpRequest<AppState>, Path<()>),
+    (req, _cube): (HttpRequest<AppState>, Path<()>),
     ) -> HttpResponse
 {
-    HttpResponse::InternalServerError().body("Error Code 555")
+    if req.state().debug {
+        // must be true, but have to destructure again after doing it before in app.rs;
+        if let CubeHasUniqueLevelsAndProperties::False { cube, name } = &req.state().has_unique_levels_properties {
+            ServerError::LogicLayerDuplicateNames { cube: cube.clone(), name: name.clone() }.error_response()
+        } else {
+            unreachable!();
+        }
+    } else {
+        ServerError::ErrorCode { code: "555".to_owned() }.error_response()
+    }
 }
 
 
 pub fn logic_layer_non_unique_levels_handler(
-    (_req, _cube): (HttpRequest<AppState>, Path<(String)>),
+    (req, _cube): (HttpRequest<AppState>, Path<(String)>),
     ) -> HttpResponse
 {
-    HttpResponse::InternalServerError().body("Error Code 555")
+    if req.state().debug {
+        // must be true, but have to destructure again after doing it before in app.rs;
+        if let CubeHasUniqueLevelsAndProperties::False { cube, name } = &req.state().has_unique_levels_properties {
+            ServerError::LogicLayerDuplicateNames { cube: cube.clone(), name: name.clone() }.error_response()
+        } else {
+            unreachable!();
+        }
+    } else {
+        ServerError::ErrorCode { code: "555".to_owned() }.error_response()
+    }
 }

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -171,7 +171,7 @@ fn main() -> Result<(), Error> {
                 cache_arc.clone(),
                 logic_layer_config.clone(),
                 streaming_response,
-                has_unique_levels_properties,
+                has_unique_levels_properties.clone(),
             )
         )
         .bind(&server_addr)


### PR DESCRIPTION
- updates methods for checking if level and property names are unique, by returning cube and name info if not. This uses a new enum.
- plumbs this data into the Actix app state.
- accesses this data in the handlers if names are not unique, and sends out the detailed message if `--debug` is set. Otherwise, keeps the current `555` error code.

closes #184 