### PR TITLE
Refactor/minor tweaks

### DIFF
--- a/tesseract-server/src/db_config.rs
+++ b/tesseract-server/src/db_config.rs
@@ -58,9 +58,9 @@ pub fn get_db(db_url_full: &str) -> Result<(Box<dyn Backend + Send + Sync>, Stri
 
     // Remove password when there's a user:password@host in the url
     // for display purposes only
-    let db_url = match &db_url.split("@").collect::<Vec<_>>()[..] {
+    let db_url = match &db_url.split('@').collect::<Vec<_>>()[..] {
         [user_pass, url] => {
-            match &user_pass.split(":").collect::<Vec<_>>()[..] {
+            match &user_pass.split(':').collect::<Vec<_>>()[..] {
                 [user, _pass] => {
                     format!("{}:*@{}", user, url)
                 },

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -35,8 +35,9 @@ macro_rules! ok_or_404 {
             Ok(val) => val,
             Err(err) => {
                 return Box::new(
-                future::result(
-                    Ok(HttpResponse::NotFound().json(err.to_string())))
+                    future::result(
+                        Ok(HttpResponse::NotFound().json(err.to_string()))
+                    )
                 );
             }
         }

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -19,7 +19,7 @@ use url::Url;
 use tesseract_core::names::{Cut, Drilldown, Property, Measure, LevelName, Mask};
 use tesseract_core::format::{format_records, FormatType};
 use tesseract_core::query::{FilterQuery, GrowthQuery, RcaQuery, TopQuery, RateQuery};
-use tesseract_core::{Query as TsQuery, MeaOrCalc, Dimension, DataFrame, Column, ColumnData, is_same_columndata_type};
+use tesseract_core::{Query as TsQuery, MeaOrCalc, DataFrame, Column, ColumnData, is_same_columndata_type};
 use tesseract_core::schema::{Cube, DimensionType};
 
 use crate::app::AppState;
@@ -452,7 +452,7 @@ pub fn generate_ts_queries(
 
     let top: Option<TopQuery> = agg_query_opt.top.clone()
         .map(|t| {
-            let top_split: Vec<String> = t.split(",").map(|s| s.to_string()).collect();
+            let top_split: Vec<String> = t.split(',').map(|s| s.to_string()).collect();
 
             if top_split.len() != 4 {
                 return Err(format_err!("Bad formatting for top param."));
@@ -485,7 +485,7 @@ pub fn generate_ts_queries(
 
     let growth = match agg_query_opt.growth {
         Some(g) => {
-            let gro_split: Vec<String> = g.split(",").map(|s| s.to_string()).collect();
+            let gro_split: Vec<String> = g.split(',').map(|s| s.to_string()).collect();
 
             if gro_split.len() == 1 {
                 return Err(format_err!("Please provide a growth measure name."));
@@ -553,7 +553,7 @@ pub fn generate_ts_queries(
     // TODO: Resolve named sets
     let rate = match agg_query_opt.rate {
         Some(rate) => {
-            let level_value_split: Vec<String> = rate.split(".").map(|s| s.to_string()).collect();
+            let level_value_split: Vec<String> = rate.split('.').map(|s| s.to_string()).collect();
 
             if level_value_split.len() != 2 {
                 bail!("Bad formatting for rate calculation.");

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::str;
 
 use actix_web::{
-    client,
     AsyncResponder,
     FutureResponse,
     HttpRequest,


### PR DESCRIPTION
* Reduces some duplicated error checking code with a macro
* Addresses a subset of clippy warnings for unused imports and using `char` type for single character patterns.