### PR TITLE
adds initial support for JWT webtoken based authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
  "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -198,15 +198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -426,14 +417,20 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.11.0"
+source = "git+https://github.com/alexcrichton/cookie-rs.git?rev=c59d94e1492f2aa8ce0949335d494322ca25366e#c59d94e1492f2aa8ce0949335d494322ca25366e"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cookie"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "cookie 0.11.0 (git+https://github.com/alexcrichton/cookie-rs.git?rev=c59d94e1492f2aa8ce0949335d494322ca25366e)"
 
 [[package]]
 name = "crc32fast"
@@ -942,7 +939,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tesseract-clickhouse 0.1.0",
  "tesseract-core 0.1.0",
- "tesseract-olap 0.14.8",
+ "tesseract-olap 0.14.9",
 ]
 
 [[package]]
@@ -986,6 +983,20 @@ dependencies = [
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jsonwebtoken"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -1708,13 +1719,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.13.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1733,11 +1746,6 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "safemem"
-version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1912,6 +1920,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2084,7 @@ dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonwebtoken 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2684,7 +2698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bb8 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0ac73ee3406f475415bba792942016291b87bac08839c38a032de56085a73b2c"
 "checksum bb8-postgres 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e44953418bdf3c469b77f9c92b78ff8c9ede8adba0adc0788765ce13f8ed9e0"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
@@ -2708,7 +2721,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clickhouse-rs 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "1ec0ac32c224574d66b99d84b7a91706de3c00fb5cfdf40ad01e72bf2e9d5cdd"
 "checksum clickhouse-rs-cityhash-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "551a67cb2913d82f0fd5fd3973c6a6a8dc7b66986f8e1a060af3ffe0c587d8f7"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99be24cfcf40d56ed37fd11c2123be833959bbc5bddecb46e1c2e442e15fa3e0"
+"checksum cookie 0.11.0 (git+https://github.com/alexcrichton/cookie-rs.git?rev=c59d94e1492f2aa8ce0949335d494322ca25366e)" = "<none>"
+"checksum cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1465f8134efa296b4c19db34d909637cb2bf0f7aaf21299e23e18fa29ac557cf"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2d818a4990769aac0c7ff1360e233ef3a41adcb009ebb2036bf6915eb0f6b23c"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
@@ -2773,6 +2787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jsonwebtoken 6.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a81d1812d731546d2614737bee92aa071d37e9afa1409bc374da9e5e70e70b22"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -2854,11 +2869,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rent_to_own 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05a51ad2b1c5c710fa89e6b1631068dab84ed687bc6a5fe061ad65da3d0c25b2"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
-"checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
+"checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b08423011dae9a5ca23f07cf57dac3857f5c885d352b76f6d95f4aea9434d0"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
@@ -2880,6 +2894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "530e1d624baae485bce12e6647acb76aafa253346ee8a16751974eed5a24b13d"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ members = [
     "tests",
 ]
 
+[replace]
+"cookie:0.11.0" = { git = 'https://github.com/alexcrichton/cookie-rs.git', rev = "c59d94e1492f2aa8ce0949335d494322ca25366e" }

--- a/tesseract-server/Cargo.toml
+++ b/tesseract-server/Cargo.toml
@@ -22,6 +22,7 @@ serde_qs = "0.4.1"
 structopt = "0.2.13"
 mime = "0.3.13"
 url = "2.1.0"
+jsonwebtoken = "6"
 
 [dependencies.actix-web]
 version = "0.7.18"

--- a/tesseract-server/src/app.rs
+++ b/tesseract-server/src/app.rs
@@ -5,7 +5,7 @@ use actix_web::{
     http::NormalizePath,
 };
 use tesseract_core::{Backend, Schema, CubeHasUniqueLevelsAndProperties};
-
+use crate::auth::ValidateAccess;
 use crate::db_config::Database;
 use crate::handlers::{
     aggregate_handler,
@@ -50,6 +50,7 @@ pub struct EnvVars {
     pub geoservice_url: Option<Url>,
     pub schema_source: SchemaSource,
     pub api_key: Option<String>,
+    pub jwt_secret: Option<String>,
     pub flush_secret: Option<String>,
 }
 
@@ -94,6 +95,7 @@ pub fn create_app(
                 logic_layer_config,
                 has_unique_levels_properties: has_unique_levels_properties.clone(),
         })
+        .middleware(ValidateAccess)
         .middleware(middleware::Logger::default())
         .middleware(middleware::DefaultHeaders::new().header("Vary", "Accept-Encoding"))
 

--- a/tesseract-server/src/auth.rs
+++ b/tesseract-server/src/auth.rs
@@ -14,7 +14,6 @@ impl Middleware<AppState> for ValidateAccess {
         let app_state: &AppState = req.state();
         let jwt_secret = &app_state.env_vars.jwt_secret;
 
-        // TODO grab from HTTP request
         let qry = req.query();
 
         let token = {

--- a/tesseract-server/src/auth.rs
+++ b/tesseract-server/src/auth.rs
@@ -1,0 +1,112 @@
+use jsonwebtoken::{decode, Validation};
+use serde_derive::{Serialize, Deserialize};
+
+use actix_web::middleware::{Middleware, Started};
+use actix_web::{HttpRequest, HttpResponse, Result};
+pub const X_TESSERACT_JWT_TOKEN: &str = "x-tesseract-jwt-token";
+use crate::app::AppState;
+
+pub struct ValidateAccess;
+
+impl Middleware<AppState> for ValidateAccess {
+    // We only need to hook into the `start` for this middleware.
+    fn start(&self, req: &HttpRequest<AppState>) -> Result<Started> {
+        let app_state: &AppState = req.state();
+        let jwt_secret = &app_state.env_vars.jwt_secret;
+
+        // TODO grab from HTTP request
+        let qry = req.query();
+
+        let token = {
+            let qp_token = qry.get(X_TESSERACT_JWT_TOKEN);
+            match qp_token {
+                None => {
+                    // If we don't match in query params, try headers
+                    // The next lines below are little ugly. Basically,
+                    // we need to catch for two potential errors:
+                    // 1. the key might not be present (phase1)
+                    // 2. the key might not parse to a string properly (phase2)
+                    let phase1 = req.headers().get(X_TESSERACT_JWT_TOKEN);
+                    match phase1 {
+                        Some(val) => {
+                            let phase2 = val.to_str();
+                            match phase2 {
+                                Ok(v) => v,
+                                _ => ""
+                            }
+                        },
+                        _ => "",
+                    }
+                },
+                Some(token) => token,
+            }
+        };
+        match validate_web_token(jwt_secret, &token) {
+            true => Ok(Started::Done),
+            false => Ok(Started::Response(
+                        HttpResponse::Unauthorized()
+                            .json("Unauthorized")
+                    ))
+            }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    status: String,
+    exp: usize,
+}
+
+
+pub fn validate_web_token(jwt_secret: &Option<String>, raw_token: &str) -> bool {
+    match jwt_secret {
+        Some(key) => {
+            let validation = Validation {
+                ..Validation::default()
+            };
+            match decode::<Claims>(&raw_token, key.as_ref(), &validation) {
+                Ok(c) => {
+                    let claims: Claims = c.claims;
+                    claims.status == "valid" // TODO allow this value to be configurable
+                },
+                Err(_) => false, // If any error occurs, do not validate
+            }
+        },
+        None => true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_jwt_auth_good() {
+        let jwt_secret = Some("hello-secret-123".to_string());
+        let result = validate_web_token(&jwt_secret, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1Nzk4ODI4NDcsImV4cCI6MjUyNjU2NzY3MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIn0.GSMVTKG3RrWOCfoDpGmJcYakspKsmjkZw7Le9lPJwtw");
+        assert_eq!(result, true);
+    }
+
+    #[test]
+    fn test_jwt_auth_bad1() {
+        let jwt_secret = Some("hello-secret-123".to_string());
+        let result = validate_web_token(&jwt_secret, "eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1Nzk4ODI4NDcsImV4cCI6MjUyNjU2NzY3MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIn0.GSMVTKG3RrWOCfoDpGmJcYakspKsmjkZw7Le9lPJwtw");
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn test_jwt_auth_bad2() {
+        let jwt_secret = Some("hello-secret-123".to_string());
+        let result = validate_web_token(&jwt_secret, "");
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn test_jwt_auth_good2() {
+        // if token is none, all requests are OK
+        let jwt_secret = None;
+        let result = validate_web_token(&jwt_secret, "");
+        assert_eq!(result, false);
+    }
+}

--- a/tesseract-server/src/auth.rs
+++ b/tesseract-server/src/auth.rs
@@ -107,6 +107,6 @@ mod test {
         // if token is none, all requests are OK
         let jwt_secret = None;
         let result = validate_web_token(&jwt_secret, "");
-        assert_eq!(result, false);
+        assert_eq!(result, true);
     }
 }

--- a/tesseract-server/src/handlers/util.rs
+++ b/tesseract-server/src/handlers/util.rs
@@ -67,6 +67,7 @@ pub fn generate_source_data(cube: &Cube) -> SourceMetadata {
 }
 
 
+
 pub fn verify_api_key(req: &HttpRequest<AppState>, cube: &Cube) -> Result<(), HttpResponse> {
     if cube.public == false {
         match &req.state().env_vars.api_key {

--- a/tesseract-server/src/lib.rs
+++ b/tesseract-server/src/lib.rs
@@ -4,3 +4,4 @@ pub mod handlers;
 pub mod logic_layer;
 pub mod schema_config;
 pub mod errors;
+pub mod auth;

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -22,6 +22,7 @@
 mod app;
 mod db_config;
 mod errors;
+mod auth;
 pub mod handlers;
 mod logic_layer;
 mod schema_config;
@@ -90,6 +91,9 @@ fn main() -> Result<(), Error> {
     // API key
     let api_key = env::var("TESSERACT_API_KEY").ok();
 
+    // JSONWebToken Secret
+    let jwt_secret = env::var("TESSERACT_JWT_SECRET").ok();
+
     // flush
     let flush_secret = env::var("TESSERACT_FLUSH_SECRET").ok();
 
@@ -130,6 +134,7 @@ fn main() -> Result<(), Error> {
         geoservice_url,
         schema_source,
         api_key,
+        jwt_secret,
         flush_secret,
     };
 

--- a/tests/src/clickhouse_end_to_end.rs
+++ b/tests/src/clickhouse_end_to_end.rs
@@ -149,6 +149,7 @@ mod tests {
             geoservice_url: None,
             schema_source,
             api_key: None,
+            jwt_secret: None,
             flush_secret: None,
         };
 


### PR DESCRIPTION
First pass at JWT webtoken support. This PR leaves in place the existing API key mechanism and adds a new JWT token based mechanism. At the moment this approach uses middleware to apply authorization to all routes uniformly (and does not currently distinguish between public/private cubes). API expects a valid token passed as `x-tesseract-jwt-token` and with claim of `status=valid` (hard-coded, for now though could also be configurable in the future).