### PR TITLE
Adds finer grained JWT access control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 rust:
   - stable
-cache: cargo
 script:
   - cargo test --all --verbose
 services:

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -154,8 +154,16 @@ impl Schema {
         self.cubes.iter().find(|c| c.name == cube_name).map(|c| c.into())
     }
 
-    pub fn metadata(&self) -> SchemaMetadata {
-        self.into()
+    pub fn metadata(&self, user_auth_level: Option<i32>) -> SchemaMetadata {
+        let mut schema_metadata: SchemaMetadata = self.into();
+        match user_auth_level {
+            Some(val) => {
+                schema_metadata.cubes = schema_metadata.cubes.drain(..).filter(|c| val >= c.min_auth_level && val >= 0).collect();
+            },
+            _ => {} // no auth
+
+        }
+        schema_metadata
     }
 
     pub fn has_unique_levels_properties(&self) -> CubeHasUniqueLevelsAndProperties {

--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -18,6 +18,10 @@ use crate::schema::{SchemaConfigJson, SchemaConfigXML};
 
 pub use self::backend::Backend;
 pub use self::dataframe::{DataFrame, Column, ColumnData, is_same_columndata_type};
+
+pub static DEFAULT_ALLOWED_ACCESS: i32 = 0;
+pub static INVALID_ACCESS: i32 = -1;
+
 use self::names::{
     Cut,
     Drilldown,
@@ -156,12 +160,8 @@ impl Schema {
 
     pub fn metadata(&self, user_auth_level: Option<i32>) -> SchemaMetadata {
         let mut schema_metadata: SchemaMetadata = self.into();
-        match user_auth_level {
-            Some(val) => {
-                schema_metadata.cubes = schema_metadata.cubes.drain(..).filter(|c| val >= c.min_auth_level && val >= 0).collect();
-            },
-            _ => {} // no auth
-
+        if let Some(val) = user_auth_level {
+            schema_metadata.cubes = schema_metadata.cubes.drain(..).filter(|c| val >= c.min_auth_level && val >= DEFAULT_ALLOWED_ACCESS).collect();
         }
         schema_metadata
     }

--- a/tesseract-core/src/schema.rs
+++ b/tesseract-core/src/schema.rs
@@ -127,19 +127,16 @@ impl From<SchemaConfigJson> for Schema {
 
             // Cubes are public by default
             let public = match cube_config.public {
-                Some(public) => {
-                    if public == "false" {
-                        false
-                    } else {
-                        true
-                    }
-                },
+                Some(public) => public != "false",
                 None => true
             };
+
+            let min_auth_level = cube_config.min_auth_level.unwrap_or(0);
 
             cubes.push(Cube {
                 name: cube_config.name,
                 public,
+                min_auth_level,
                 table: cube_config.table.into(),
                 can_aggregate: false,
                 dimensions,
@@ -170,6 +167,7 @@ impl From<SchemaConfigJson> for Schema {
 pub struct Cube {
     pub name: String,
     pub public: bool,
+    pub min_auth_level: i32,
     pub table: Table,
     pub can_aggregate: bool,
     pub dimensions: Vec<Dimension>,
@@ -790,6 +788,7 @@ mod test {
                 CubeConfigJson {
                     name: "test_cube".into(),
                     public: Some("true".into()),
+                    min_auth_level: None,
                     table: TableConfigJson {
                         name: "fact_table".into(),
                         schema: None,

--- a/tesseract-core/src/schema.rs
+++ b/tesseract-core/src/schema.rs
@@ -34,7 +34,7 @@ pub use crate::schema::{
 use crate::names::{LevelName, Measure as MeasureName, Property as TsProperty};
 use crate::query_ir::MemberType;
 pub use self::aggregator::Aggregator;
-
+use crate::DEFAULT_ALLOWED_ACCESS;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Schema {
@@ -131,7 +131,7 @@ impl From<SchemaConfigJson> for Schema {
                 None => true
             };
 
-            let min_auth_level = cube_config.min_auth_level.unwrap_or(0);
+            let min_auth_level = cube_config.min_auth_level.unwrap_or(DEFAULT_ALLOWED_ACCESS);
 
             cubes.push(Cube {
                 name: cube_config.name,

--- a/tesseract-core/src/schema/json.rs
+++ b/tesseract-core/src/schema/json.rs
@@ -18,6 +18,7 @@ pub struct SchemaConfigJson {
 pub struct CubeConfigJson {
     pub name: String,
     pub public: Option<String>,
+    pub min_auth_level: Option<i32>,
     pub table: TableConfigJson,
     pub dimensions: Option<Vec<DimensionConfigJson>>,
     pub dimension_usages: Option<Vec<DimensionUsageJson>>,

--- a/tesseract-core/src/schema/metadata.rs
+++ b/tesseract-core/src/schema/metadata.rs
@@ -41,7 +41,8 @@ pub struct CubeMetadata {
     pub dimensions: Vec<DimensionMetadata>,
     pub measures: Vec<MeasureMetadata>,
     pub annotations: AnnotationMetadata,
-    pub alias: Option<Vec<String>>
+    pub alias: Option<Vec<String>>,
+    pub min_auth_level: i32,
 }
 
 impl From<&Cube> for CubeMetadata {
@@ -54,6 +55,7 @@ impl From<&Cube> for CubeMetadata {
             measures: cube.measures.iter().map(|m| m.into()).collect(),
             annotations,
             alias: None,
+            min_auth_level: cube.min_auth_level,
         }
     }
 }

--- a/tesseract-core/src/schema/xml.rs
+++ b/tesseract-core/src/schema/xml.rs
@@ -33,6 +33,8 @@ pub struct SchemaConfigXML {
 pub struct CubeConfigXML {
     pub name: String,
     pub public: Option<String>,
+    #[serde(rename(deserialize="minAuthLevel"))]
+    pub min_auth_level: Option<i32>,
     #[serde(rename(deserialize="Table"))]
     pub table: TableConfigXML,
     #[serde(rename(deserialize="Dimension"))]

--- a/tesseract-core/src/schema/xml.rs
+++ b/tesseract-core/src/schema/xml.rs
@@ -33,7 +33,7 @@ pub struct SchemaConfigXML {
 pub struct CubeConfigXML {
     pub name: String,
     pub public: Option<String>,
-    #[serde(rename(deserialize="minAuthLevel"))]
+    #[serde(rename(deserialize="min_auth_level"))]
     pub min_auth_level: Option<i32>,
     #[serde(rename(deserialize="Table"))]
     pub table: TableConfigXML,
@@ -186,7 +186,7 @@ mod test {
                         <Level name="Tract" key_column="geoid" />
                     </Hierarchy>
                 </SharedDimension>
-                <Cube name="my_cube" minAuthLevel="1">
+                <Cube name="my_cube" min_auth_level="1">
                     <Table name="my_table" />
                     <Dimension name="my_dim">
                         <Hierarchy name="my_hier">

--- a/tesseract-core/src/schema/xml.rs
+++ b/tesseract-core/src/schema/xml.rs
@@ -186,7 +186,7 @@ mod test {
                         <Level name="Tract" key_column="geoid" />
                     </Hierarchy>
                 </SharedDimension>
-                <Cube name="my_cube">
+                <Cube name="my_cube" minAuthLevel="1">
                     <Table name="my_table" />
                     <Dimension name="my_dim">
                         <Hierarchy name="my_hier">
@@ -198,5 +198,7 @@ mod test {
             </Schema>
         "##;
         let xml_schema_config: SchemaConfigXML = from_reader(s.as_bytes()).unwrap();
+        let cube = &xml_schema_config.cubes[0];
+        assert_eq!(cube.min_auth_level.unwrap(), 1)
     }
 }

--- a/tesseract-server/src/auth.rs
+++ b/tesseract-server/src/auth.rs
@@ -7,46 +7,22 @@ pub const X_TESSERACT_JWT_TOKEN: &str = "x-tesseract-jwt-token";
 use crate::app::AppState;
 
 pub struct ValidateAccess;
-
+pub static DEFAULT_ALLOWED_ACCESS: i32 = 0;
 impl Middleware<AppState> for ValidateAccess {
     // We only need to hook into the `start` for this middleware.
     fn start(&self, req: &HttpRequest<AppState>) -> Result<Started> {
         let app_state: &AppState = req.state();
         let jwt_secret = &app_state.env_vars.jwt_secret;
 
-        let qry = req.query();
-
-        let token = {
-            let qp_token = qry.get(X_TESSERACT_JWT_TOKEN);
-            match qp_token {
-                None => {
-                    // If we don't match in query params, try headers
-                    // The next lines below are little ugly. Basically,
-                    // we need to catch for two potential errors:
-                    // 1. the key might not be present (phase1)
-                    // 2. the key might not parse to a string properly (phase2)
-                    let phase1 = req.headers().get(X_TESSERACT_JWT_TOKEN);
-                    match phase1 {
-                        Some(val) => {
-                            let phase2 = val.to_str();
-                            match phase2 {
-                                Ok(v) => v,
-                                _ => ""
-                            }
-                        },
-                        _ => "",
-                    }
-                },
-                Some(token) => token,
-            }
-        };
-        match validate_web_token(jwt_secret, &token) {
-            true => Ok(Started::Done),
-            false => Ok(Started::Response(
+        let token = extract_token(&req);
+        if validate_web_token(jwt_secret, &token, DEFAULT_ALLOWED_ACCESS) {
+            Ok(Started::Done)
+        } else {
+            Ok(Started::Response(
                         HttpResponse::Unauthorized()
                             .json("Unauthorized")
                     ))
-            }
+        }
     }
 }
 
@@ -55,21 +31,54 @@ struct Claims {
     sub: String,
     status: String,
     exp: usize,
+    auth_level: Option<i32>,
 }
 
+pub fn extract_token(req: &HttpRequest<AppState>) -> String {
+    let qry = req.query();
 
-pub fn validate_web_token(jwt_secret: &Option<String>, raw_token: &str) -> bool {
+    let token = {
+        let qp_token = qry.get(X_TESSERACT_JWT_TOKEN);
+        match qp_token {
+            None => {
+                // If we don't match in query params, try headers
+                // The next lines below are little ugly. Basically,
+                // we need to catch for two potential errors:
+                // 1. the key might not be present (phase1)
+                // 2. the key might not parse to a string properly (phase2)
+                let phase1 = req.headers().get(X_TESSERACT_JWT_TOKEN);
+                match phase1 {
+                    Some(val) => {
+                        let phase2 = val.to_str();
+                        match phase2 {
+                            Ok(v) => v,
+                            _ => ""
+                        }
+                    },
+                    _ => "",
+                }
+            },
+            Some(token) => token,
+        }
+    };
+    token.to_string()
+}
+
+pub fn validate_web_token(jwt_secret: &Option<String>, raw_token: &str, min_auth_level: i32) -> bool {
     match jwt_secret {
         Some(key) => {
-            let validation = Validation {
-                ..Validation::default()
-            };
+            let validation = Validation::default();
             match decode::<Claims>(&raw_token, key.as_ref(), &validation) {
                 Ok(c) => {
                     let claims: Claims = c.claims;
-                    claims.status == "valid" // TODO allow this value to be configurable
+                    let part1 = claims.status == "valid"; // TODO allow this value to be configurable
+                    let part2 = match claims.auth_level {
+                        Some(lvl) => lvl >= min_auth_level,
+                        None => true
+                    };
+                    part1 && part2
                 },
-                Err(_) => false, // If any error occurs, do not validate
+                Err(_err) => false, // If any error occurs, do not validate
             }
         },
         None => true
@@ -83,21 +92,21 @@ mod test {
     #[test]
     fn test_jwt_auth_good() {
         let jwt_secret = Some("hello-secret-123".to_string());
-        let result = validate_web_token(&jwt_secret, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1Nzk4ODI4NDcsImV4cCI6MjUyNjU2NzY3MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIn0.GSMVTKG3RrWOCfoDpGmJcYakspKsmjkZw7Le9lPJwtw");
+        let result = validate_web_token(&jwt_secret, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1ODA0MjA2NzQsImV4cCI6MTczODE4NzA4OSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIiwiYXV0aF9sZXZlbCI6Mn0.IUkh8-y9LIcNcxpmCJyLK09SY9LDm8P0ekJcL4OZKNI", DEFAULT_ALLOWED_ACCESS);
         assert_eq!(result, true);
     }
 
     #[test]
     fn test_jwt_auth_bad1() {
         let jwt_secret = Some("hello-secret-123".to_string());
-        let result = validate_web_token(&jwt_secret, "eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1Nzk4ODI4NDcsImV4cCI6MjUyNjU2NzY3MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIn0.GSMVTKG3RrWOCfoDpGmJcYakspKsmjkZw7Le9lPJwtw");
+        let result = validate_web_token(&jwt_secret, "eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1Nzk4ODI4NDcsImV4cCI6MjUyNjU2NzY3MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIn0.GSMVTKG3RrWOCfoDpGmJcYakspKsmjkZw7Le9lPJwtw", DEFAULT_ALLOWED_ACCESS);
         assert_eq!(result, false);
     }
 
     #[test]
     fn test_jwt_auth_bad2() {
         let jwt_secret = Some("hello-secret-123".to_string());
-        let result = validate_web_token(&jwt_secret, "");
+        let result = validate_web_token(&jwt_secret, "", DEFAULT_ALLOWED_ACCESS);
         assert_eq!(result, false);
     }
 
@@ -105,7 +114,21 @@ mod test {
     fn test_jwt_auth_good2() {
         // if token is none, all requests are OK
         let jwt_secret = None;
-        let result = validate_web_token(&jwt_secret, "");
+        let result = validate_web_token(&jwt_secret, "", DEFAULT_ALLOWED_ACCESS);
         assert_eq!(result, true);
+    }
+
+    #[test]
+    fn test_jwt_auth_level_overflow_bad() {
+        let jwt_secret = Some("hello-secret-123".to_string());
+        let result = validate_web_token(&jwt_secret, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1ODAyNDg2OTAsImV4cCI6MTU4MDI1MjgyNiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIiwiYXV0aF9sZXZlbCI6NWUrNDUsImp0aSI6IjIzYmIwMDg5LWQ2NDctNDNlOC04YjdiLWIxOGU4N2ViMjljZCJ9.-d7k5i6oGopyBzSbiD9rl9FyYQUR_hwy4tvYzgfMb1M", DEFAULT_ALLOWED_ACCESS);
+        assert_eq!(result, false);
+    }
+
+    #[test]
+    fn test_auth_level_too_low_bad() {
+        let jwt_secret = Some("hello-secret-123".to_string());
+        let result = validate_web_token(&jwt_secret, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1ODA0MjA2NzQsImV4cCI6MTczODE4NzA4OSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInN0YXR1cyI6InZhbGlkIiwiYXV0aF9sZXZlbCI6Mn0.IUkh8-y9LIcNcxpmCJyLK09SY9LDm8P0ekJcL4OZKNI", 100);
+        assert_eq!(result, false);
     }
 }

--- a/tesseract-server/src/handlers/metadata.rs
+++ b/tesseract-server/src/handlers/metadata.rs
@@ -15,6 +15,7 @@ use serde_qs as qs;
 use tesseract_core::format::{format_records, FormatType};
 use tesseract_core::names::{LevelName, Property};
 use tesseract_core::schema::metadata::{CubeMetadata, PropertyMetadata};
+use tesseract_core::DEFAULT_ALLOWED_ACCESS;
 
 use crate::app::AppState;
 use crate::logic_layer::LogicLayerConfig;
@@ -57,7 +58,7 @@ pub fn metadata_all_handler(
         // Filter out cube that user isn't authorized to see
         match user_auth_level {
             Some(auth_level) => { // Authorization is set
-                if (auth_level >= cube.min_auth_level && auth_level >= 0) {
+                if (auth_level >= cube.min_auth_level && auth_level >= DEFAULT_ALLOWED_ACCESS) {
                     cubes.push(get_cube_metadata(cube.clone(), &ll_config));
                 }
             },

--- a/tesseract-server/src/handlers/metadata.rs
+++ b/tesseract-server/src/handlers/metadata.rs
@@ -18,7 +18,7 @@ use tesseract_core::schema::metadata::{CubeMetadata, PropertyMetadata};
 
 use crate::app::AppState;
 use crate::logic_layer::LogicLayerConfig;
-use super::util::{boxed_error_http_response, verify_api_key};
+use super::util::{boxed_error_http_response, verify_api_key, get_user_auth_level};
 
 
 pub fn metadata_handler(
@@ -44,14 +44,26 @@ pub fn metadata_all_handler(
     ) -> ActixResult<HttpResponse>
 {
     info!("Metadata for all");
-    let mut schema_details = req.state().schema.read().unwrap().metadata();
+    let user_auth_level = get_user_auth_level(&req);
+    let mut schema_details = req.state().schema.read().unwrap().metadata(user_auth_level);
     let ll_config = match &req.state().logic_layer_config {
         Some(llc) => llc.read().unwrap().clone(),
-        None => return  Ok(HttpResponse::Ok().json(schema_details))
+        None => {
+            return  Ok(HttpResponse::Ok().json(schema_details))
+        }
     };
     let mut cubes: Vec<CubeMetadata> = Vec::new();
     for cube in schema_details.cubes.iter(){
-        cubes.push(get_cube_metadata(cube.clone(), &ll_config));
+        // Filter out cube that user isn't authorized to see
+        match user_auth_level {
+            Some(auth_level) => { // Authorization is set
+                if (auth_level >= cube.min_auth_level && auth_level >= 0) {
+                    cubes.push(get_cube_metadata(cube.clone(), &ll_config));
+                }
+            },
+            // No authorization set. Show all cubes
+            None => cubes.push(get_cube_metadata(cube.clone(), &ll_config))
+        }
     }
     schema_details.cubes = cubes;
     Ok(HttpResponse::Ok().json(schema_details))

--- a/tesseract-server/src/handlers/util.rs
+++ b/tesseract-server/src/handlers/util.rs
@@ -17,7 +17,7 @@ use crate::app::AppState;
 use failure::{bail, format_err, Error};
 use tesseract_core::names::Cut;
 use crate::logic_layer::CubeCache;
-use crate::auth::{validate_web_token, extract_token};
+use crate::auth::{validate_web_token, extract_token, user_auth_level};
 
 pub(crate) fn format_to_content_type(format_type: &FormatType) -> ContentType {
     match format_type {
@@ -70,7 +70,11 @@ pub fn generate_source_data(cube: &Cube) -> SourceMetadata {
     }
 }
 
-
+pub fn get_user_auth_level(req: &HttpRequest<AppState>) -> Option<i32> {
+    let jwt_secret = &req.state().env_vars.jwt_secret;
+    let user_token = extract_token(req);
+    user_auth_level(jwt_secret, &user_token)
+}
 
 pub fn verify_api_key(req: &HttpRequest<AppState>, cube: &Cube) -> Result<(), HttpResponse> {
     if cube.public == false {

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -190,6 +190,12 @@ fn main() -> Result<(), Error> {
     println!("Tesseract database:     {}, {}", db_url, db_type_viz);
     println!("Tesseract schema path:  {}", schema_path);
 
+    if jwt_secret.is_some() {
+        println!("Tesseract JWT token protection: ON");
+    } else {
+        println!("Tesseract JWT token protection: OFF");
+    }
+
     if debug {
         println!("Tesseract debug mode: ON");
     }

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -127,7 +127,11 @@ fn main() -> Result<(), Error> {
     schema.validate()?;
     let mut has_unique_levels_properties = schema.has_unique_levels_properties();
     let schema_arc = Arc::new(RwLock::new(schema.clone()));
-
+    let jwt_status = if jwt_secret.is_some() {
+        "ON"
+    } else {
+        "OFF"
+    };
     // Env
     let env_vars = EnvVars {
         database_url: db_url.clone(),
@@ -190,11 +194,7 @@ fn main() -> Result<(), Error> {
     println!("Tesseract database:     {}, {}", db_url, db_type_viz);
     println!("Tesseract schema path:  {}", schema_path);
 
-    if jwt_secret.is_some() {
-        println!("Tesseract JWT token protection: ON");
-    } else {
-        println!("Tesseract JWT token protection: OFF");
-    }
+    println!("Tesseract JWT token protection: {}", jwt_status);
 
     if debug {
         println!("Tesseract debug mode: ON");


### PR DESCRIPTION
* Users can now give cubes a `minAuthLevel` value. This will require that tokens must have at least that level or higher in the `auth_level` claim of their token. By default valid users without an explicit auth level will have an auth level of 0, and also cubes will have a default auth level of 0.
* The `/cubes` endpoint listing will now filter out cubes that a user does not have access to.