### PR TITLE
Faster CubeCache return

### DIFF
--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -200,7 +200,9 @@ pub fn logic_layer_aggregation(
         Err(err) => return boxed_error_http_response(err)
     }
 
-    let cube_cache = match req.state().cache.read().unwrap().find_cube_info(&cube_name) {
+    let cache = req.state().cache.read().unwrap();
+
+    let cube_cache = match cache.find_cube_info(&cube_name) {
         Some(cube_cache) => cube_cache,
         None => return boxed_error_string("Unable to access cube cache".to_string())
     };

--- a/tesseract-server/src/handlers/logic_layer/relations.rs
+++ b/tesseract-server/src/handlers/logic_layer/relations.rs
@@ -103,7 +103,9 @@ pub fn logic_layer_relations(
         Err(err) => return Ok(err)
     }
 
-    let cube_cache = match req.state().cache.read().unwrap().find_cube_info(&cube_name) {
+    let cache = req.state().cache.read().unwrap();
+
+    let cube_cache = match cache.find_cube_info(&cube_name) {
         Some(cube_cache) => cube_cache,
         None => return Ok(HttpResponse::NotFound().json("Unable to access cube cache".to_string()))
     };

--- a/tesseract-server/src/logic_layer/cache.rs
+++ b/tesseract-server/src/logic_layer/cache.rs
@@ -119,10 +119,10 @@ pub struct Cache {
 
 impl Cache {
     /// Finds the `CubeCache` object for a cube with a given name.
-    pub fn find_cube_info(&self, cube: &String) -> Option<CubeCache> {
+    pub fn find_cube_info(&self, cube: &String) -> Option<&CubeCache> {
         for cube_cache in &self.cubes {
             if cube_cache.name == *cube {
-                return Some(cube_cache.clone());
+                return Some(cube_cache);
             }
         }
         None


### PR DESCRIPTION
We noticed that [this query](https://api.oec.world/tesseract/relations.jsonrecords?cube=patents_i_uspto_w_cpc&Subclass=H01Q:parents) was taking forever to return results. Upon closer inspection, we were doing an unnecessary clone that is now removed.