### PR TITLE
Adds unique header names when appropriate

### DIFF
--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -1545,7 +1545,7 @@ mod test {
             sparse: false,
             exclude_default_members: false,
         };
-        let query_ir_headers = Schema::from_xml(s).unwrap().sql_query("Sales", &query);
+        let query_ir_headers = Schema::from_xml(s).unwrap().sql_query("Sales", &query, None);
         let (query_ir, _headers) = query_ir_headers.unwrap();
         assert_eq!(query_ir.sort, Some(SortSql{direction: SortDirection::Asc, column: "final_m0".to_string()}))
     }
@@ -1706,7 +1706,7 @@ mod test {
             sparse: false,
             exclude_default_members: false,
         };
-        let query_ir_headers = Schema::from_xml(s).unwrap().sql_query("Sales", &query);
+        let query_ir_headers = Schema::from_xml(s).unwrap().sql_query("Sales", &query, None);
         let (query_ir, _headers) = query_ir_headers.unwrap();
         assert_eq!(query_ir.filters, [FilterSql {
             by_column: "final_m1".to_string(),

--- a/tesseract-server/src/handlers/aggregate.rs
+++ b/tesseract-server/src/handlers/aggregate.rs
@@ -92,7 +92,7 @@ pub fn do_aggregate(
         ok_or_404!(validate_members(&ts_query.cuts, &cube_cache));
     }
 
-    let query_ir_headers = schema.sql_query(&cube, &ts_query);
+    let query_ir_headers = schema.sql_query(&cube, &ts_query, None);
     let (query_ir, headers) = ok_or_404!(query_ir_headers);
 
     let sql = req.state()

--- a/tesseract-server/src/handlers/aggregate_stream.rs
+++ b/tesseract-server/src/handlers/aggregate_stream.rs
@@ -75,7 +75,7 @@ pub fn do_aggregate(
     let query_ir_headers = req
         .state()
         .schema.read().unwrap()
-        .sql_query(&cube, &ts_query);
+        .sql_query(&cube, &ts_query, None);
 
     let (query_ir, headers) = ok_or_404!(query_ir_headers);
 

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -224,35 +224,11 @@ pub fn logic_layer_aggregation(
     }
 
     // Need to create a map here to help create unique header names in the next step
-    let mut unique_header_map: HashMap<String, String> = HashMap::new();
-
-    if let Some(ref llc) = logic_layer_config {
-        if let Some(ref llc_aliases) = llc.aliases {
-            if let Some(ref llc_cubes) = llc_aliases.cubes {
-                for llc_cube in llc_cubes {
-                    if cube_name == llc_cube.name {
-                        if let Some(ref llc_cube_levels) = llc_cube.levels {
-                            for llc_cube_level in llc_cube_levels {
-                                unique_header_map.insert(
-                                    llc_cube_level.current_name.clone(),
-                                    llc_cube_level.unique_name.clone()
-                                );
-                            }
-                        }
-
-                        if let Some(ref llc_cube_properties) = llc_cube.properties {
-                            for llc_cube_property in llc_cube_properties {
-                                unique_header_map.insert(
-                                    llc_cube_property.current_name.clone(),
-                                    llc_cube_property.unique_name.clone()
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+    let unique_header_map: HashMap<String, String> = if let Some(ref llc) = logic_layer_config {
+        llc.get_unique_names_map(cube_name.clone())
+    } else {
+        HashMap::new()
+    };
 
     let mut sql_strings: Vec<String> = vec![];
     let mut final_headers: Vec<String> = vec![];

--- a/tesseract-server/src/logic_layer/config.rs
+++ b/tesseract-server/src/logic_layer/config.rs
@@ -1,5 +1,5 @@
 use failure::{Error, format_err};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use serde_derive::Deserialize;
 use serde_json;
@@ -158,6 +158,40 @@ pub fn read_config(config_path: &String) -> Result<LogicLayerConfig, Error> {
 }
 
 impl LogicLayerConfig {
+    /// Returns a HashMap of current level signatures to unique level signatures
+    /// for a given cube name.
+    pub fn get_unique_names_map(&self, cube_name: String) -> HashMap<String, String> {
+        let mut unique_header_map: HashMap<String, String> = HashMap::new();
+
+        if let Some(ref aliases) = self.aliases {
+            if let Some(ref llc_cubes) = aliases.cubes {
+                for llc_cube in llc_cubes {
+                    if cube_name == llc_cube.name {
+                        if let Some(ref llc_cube_levels) = llc_cube.levels {
+                            for llc_cube_level in llc_cube_levels {
+                                unique_header_map.insert(
+                                    llc_cube_level.current_name.clone(),
+                                    llc_cube_level.unique_name.clone()
+                                );
+                            }
+                        }
+
+                        if let Some(ref llc_cube_properties) = llc_cube.properties {
+                            for llc_cube_property in llc_cube_properties {
+                                unique_header_map.insert(
+                                    llc_cube_property.current_name.clone(),
+                                    llc_cube_property.unique_name.clone()
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        unique_header_map
+    }
+
     /// Given a cube name, loops over the LogicLayerConfig and returns the
     /// actual cube name if an alias was provided.
     pub fn substitute_cube_name(self, name: String) -> Result<String, Error> {


### PR DESCRIPTION
Right now unique level names are not being returned as the header in the response: https://api.oec.world/tesseract/data.jsonrecords?cube=trade_i_baci_a_92&drilldowns=Exporter+Continent%2CImporter+Continent&measures=Trade+Value&parents=false&sparse=false

This PR fixes that by substituting the header names for the unique version whenever there are multiple headers with the same name.

Sample response from the same query:

![Screen Shot 2020-02-20 at 1 38 36 PM](https://user-images.githubusercontent.com/6521281/74967104-5b71f580-53e6-11ea-9067-0608e65d8d59.png)
