### PR TITLE
Authorization refactor

### DIFF
--- a/tesseract-core/src/lib.rs
+++ b/tesseract-core/src/lib.rs
@@ -20,7 +20,6 @@ pub use self::backend::Backend;
 pub use self::dataframe::{DataFrame, Column, ColumnData, is_same_columndata_type};
 
 pub static DEFAULT_ALLOWED_ACCESS: i32 = 0;
-pub static INVALID_ACCESS: i32 = -1;
 
 use self::names::{
     Cut,

--- a/tesseract-server/src/app.rs
+++ b/tesseract-server/src/app.rs
@@ -5,7 +5,6 @@ use actix_web::{
     http::NormalizePath,
 };
 use tesseract_core::{Backend, Schema, CubeHasUniqueLevelsAndProperties};
-use crate::auth::ValidateAccess;
 use crate::db_config::Database;
 use crate::handlers::{
     aggregate_handler,
@@ -97,7 +96,6 @@ pub fn create_app(
                 logic_layer_config,
                 has_unique_levels_properties: has_unique_levels_properties.clone(),
         })
-        .middleware(ValidateAccess)
         .middleware(middleware::Logger::default())
         .middleware(middleware::DefaultHeaders::new().header("Vary", "Accept-Encoding"))
 

--- a/tesseract-server/src/app.rs
+++ b/tesseract-server/src/app.rs
@@ -50,7 +50,6 @@ pub struct EnvVars {
     pub database_url: String,
     pub geoservice_url: Option<Url>,
     pub schema_source: SchemaSource,
-    pub api_key: Option<String>,
     pub jwt_secret: Option<String>,
     pub flush_secret: Option<String>,
 }

--- a/tesseract-server/src/handlers/diagnosis.rs
+++ b/tesseract-server/src/handlers/diagnosis.rs
@@ -21,7 +21,7 @@ use tesseract_core::{DataFrame, Column, ColumnData};
 use tesseract_core::schema::{Cube, DimensionType, Level};
 use crate::app::AppState;
 use crate::logic_layer::{LogicLayerConfig, CubeCache};
-use crate::handlers::util::{verify_api_key, format_to_content_type};
+use crate::handlers::util::{verify_authorization, format_to_content_type};
 use crate::handlers::logic_layer::{query_geoservice, GeoserviceQuery};
 
 
@@ -81,9 +81,8 @@ pub fn perform_diagnosis(
         Err(err) => return Ok(HttpResponse::NotFound().json(err.to_string()))
     };
 
-    match verify_api_key(&req, &cube) {
-        Ok(_) => (),
-        Err(err) => return Ok(err)
+    if let Err(err) = verify_authorization(&req, cube.min_auth_level) {
+        return Ok(err);
     }
 
     let mut error_types: Vec<String> = vec![];

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -28,7 +28,7 @@ use crate::errors::ServerError;
 use crate::logic_layer::{LogicLayerConfig, CubeCache, Time};
 use super::super::util::{
     boxed_error_string, boxed_error_http_response,
-    verify_api_key, format_to_content_type, generate_source_data,
+    verify_authorization, format_to_content_type, generate_source_data,
     validate_members
 };
 use crate::handlers::logic_layer::{query_geoservice, GeoserviceQuery};
@@ -195,9 +195,8 @@ pub fn logic_layer_aggregation(
 
     let cube = ok_or_404!(schema.get_cube_by_name(&cube_name));
 
-    match verify_api_key(&req, &cube) {
-        Ok(_) => (),
-        Err(err) => return boxed_error_http_response(err)
+    if let Err(err) = verify_authorization(&req, cube.min_auth_level) {
+        return boxed_error_http_response(err);
     }
 
     let cache = req.state().cache.read().unwrap();

--- a/tesseract-server/src/handlers/logic_layer/metadata.rs
+++ b/tesseract-server/src/handlers/logic_layer/metadata.rs
@@ -20,7 +20,7 @@ use tesseract_core::names::LevelName;
 
 use super::super::util::{
     boxed_error_string, boxed_error_http_response,
-    verify_api_key, format_to_content_type
+    verify_authorization, format_to_content_type
 };
 
 
@@ -75,9 +75,8 @@ pub fn get_members(
     // Get cube object to check for API key
     let cube_obj = ok_or_404!(schema.get_cube_by_name(&cube_name));
 
-    match verify_api_key(&req, &cube_obj) {
-        Ok(_) => (),
-        Err(err) => return boxed_error_http_response(err)
+    if let Err(err) = verify_authorization(&req, cube_obj.min_auth_level) {
+        return boxed_error_http_response(err);
     }
 
     if let Some(logic_layer_config) = &logic_layer_config {

--- a/tesseract-server/src/handlers/logic_layer/relations.rs
+++ b/tesseract-server/src/handlers/logic_layer/relations.rs
@@ -20,7 +20,7 @@ use tesseract_core::{DataFrame, Column, ColumnData};
 use tesseract_core::schema::{Cube, DimensionType};
 use crate::app::AppState;
 use crate::logic_layer::{LogicLayerConfig, CubeCache};
-use super::super::util::{verify_api_key, format_to_content_type};
+use super::super::util::{verify_authorization, format_to_content_type};
 use crate::handlers::logic_layer::{query_geoservice, GeoserviceQuery};
 
 
@@ -98,9 +98,8 @@ pub fn logic_layer_relations(
         Err(err) => return Ok(HttpResponse::NotFound().json(err.to_string()))
     };
 
-    match verify_api_key(&req, &cube) {
-        Ok(_) => (),
-        Err(err) => return Ok(err)
+    if let Err(err) = verify_authorization(&req, cube.min_auth_level) {
+        return Ok(err);
     }
 
     let cache = req.state().cache.read().unwrap();

--- a/tesseract-server/src/main.rs
+++ b/tesseract-server/src/main.rs
@@ -88,9 +88,6 @@ fn main() -> Result<(), Error> {
     // address
     let server_addr = opt.address.unwrap_or("127.0.0.1:7777".to_owned());
 
-    // API key
-    let api_key = env::var("TESSERACT_API_KEY").ok();
-
     // JSONWebToken Secret
     let jwt_secret = env::var("TESSERACT_JWT_SECRET").ok();
 
@@ -137,7 +134,6 @@ fn main() -> Result<(), Error> {
         database_url: db_url.clone(),
         geoservice_url,
         schema_source,
-        api_key,
         jwt_secret,
         flush_secret,
     };

--- a/tests/src/clickhouse_end_to_end.rs
+++ b/tests/src/clickhouse_end_to_end.rs
@@ -148,7 +148,6 @@ mod tests {
             database_url: db_url.clone(),
             geoservice_url: None,
             schema_source,
-            api_key: None,
             jwt_secret: None,
             flush_secret: None,
         };


### PR DESCRIPTION
* removes old API key verification.
* reworks JWT auth to allow access by default. (All requests will be considered to have an `auth_level` of 0)