### PR TITLE
Logic Layer support for "exclude"

### DIFF
--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -440,7 +440,7 @@ pub fn logic_layer_aggregation(
                 // multiple data types. In those cases, we will convert the
                 // whole column to string values.
                 if same_type {
-                    let mut column_data: ColumnData = ColumnData::Text(col_data.clone());
+                    let mut column_data: ColumnData = ColumnData::Text(vec![]);
 
                     match first_col.column_data {
                         ColumnData::Int8(_) => {
@@ -512,7 +512,9 @@ pub fn logic_layer_aggregation(
                                 }
                             }).collect());
                         }
-                        _ => ()
+                        _ => {
+                            column_data = ColumnData::Text(col_data.clone());
+                        }
                     }
 
                     final_columns.push(Column {

--- a/tesseract-server/src/handlers/logic_layer/aggregate.rs
+++ b/tesseract-server/src/handlers/logic_layer/aggregate.rs
@@ -440,82 +440,80 @@ pub fn logic_layer_aggregation(
                 // multiple data types. In those cases, we will convert the
                 // whole column to string values.
                 if same_type {
-                    let mut column_data: ColumnData = ColumnData::Text(vec![]);
-
-                    match first_col.column_data {
+                    let column_data = match first_col.column_data {
                         ColumnData::Int8(_) => {
-                            column_data = ColumnData::Int8(consolidate_column_data!(&col_data, i8));
+                            ColumnData::Int8(consolidate_column_data!(&col_data, i8))
                         },
                         ColumnData::Int16(_) => {
-                            column_data = ColumnData::Int16(consolidate_column_data!(&col_data, i16));
+                            ColumnData::Int16(consolidate_column_data!(&col_data, i16))
                         },
                         ColumnData::Int32(_) => {
-                            column_data = ColumnData::Int32(consolidate_column_data!(&col_data, i32));
+                            ColumnData::Int32(consolidate_column_data!(&col_data, i32))
                         },
                         ColumnData::Int64(_) => {
-                            column_data = ColumnData::Int64(consolidate_column_data!(&col_data, i64));
+                            ColumnData::Int64(consolidate_column_data!(&col_data, i64))
                         },
                         ColumnData::UInt8(_) => {
-                            column_data = ColumnData::UInt8(consolidate_column_data!(&col_data, u8));
+                            ColumnData::UInt8(consolidate_column_data!(&col_data, u8))
                         },
                         ColumnData::UInt16(_) => {
-                            column_data = ColumnData::UInt16(consolidate_column_data!(&col_data, u16));
+                            ColumnData::UInt16(consolidate_column_data!(&col_data, u16))
                         },
                         ColumnData::UInt32(_) => {
-                            column_data = ColumnData::UInt32(consolidate_column_data!(&col_data, u32));
+                            ColumnData::UInt32(consolidate_column_data!(&col_data, u32))
                         },
                         ColumnData::UInt64(_) => {
-                            column_data = ColumnData::UInt64(consolidate_column_data!(&col_data, u64));
+                            ColumnData::UInt64(consolidate_column_data!(&col_data, u64))
                         },
                         ColumnData::Float32(_) => {
-                            column_data = ColumnData::Float32(consolidate_column_data!(&col_data, f32));
+                            ColumnData::Float32(consolidate_column_data!(&col_data, f32))
                         },
                         ColumnData::Float64(_) => {
-                            column_data = ColumnData::Float64(consolidate_column_data!(&col_data, f64));
+                            ColumnData::Float64(consolidate_column_data!(&col_data, f64))
                         },
                         ColumnData::NullableInt8(_) => {
-                            column_data = ColumnData::NullableInt8(consolidate_null_column_data!(&col_data, i8));
+                            ColumnData::NullableInt8(consolidate_null_column_data!(&col_data, i8))
                         },
                         ColumnData::NullableInt16(_) => {
-                            column_data = ColumnData::NullableInt16(consolidate_null_column_data!(&col_data, i16));
+                            ColumnData::NullableInt16(consolidate_null_column_data!(&col_data, i16))
                         },
                         ColumnData::NullableInt32(_) => {
-                            column_data = ColumnData::NullableInt32(consolidate_null_column_data!(&col_data, i32));
+                            ColumnData::NullableInt32(consolidate_null_column_data!(&col_data, i32))
                         },
                         ColumnData::NullableInt64(_) => {
-                            column_data = ColumnData::NullableInt64(consolidate_null_column_data!(&col_data, i64));
+                            ColumnData::NullableInt64(consolidate_null_column_data!(&col_data, i64))
                         },
                         ColumnData::NullableUInt8(_) => {
-                            column_data = ColumnData::NullableUInt8(consolidate_null_column_data!(&col_data, u8));
+                            ColumnData::NullableUInt8(consolidate_null_column_data!(&col_data, u8))
                         },
                         ColumnData::NullableUInt16(_) => {
-                            column_data = ColumnData::NullableUInt16(consolidate_null_column_data!(&col_data, u16));
+                            ColumnData::NullableUInt16(consolidate_null_column_data!(&col_data, u16))
                         },
                         ColumnData::NullableUInt32(_) => {
-                            column_data = ColumnData::NullableUInt32(consolidate_null_column_data!(&col_data, u32));
+                            ColumnData::NullableUInt32(consolidate_null_column_data!(&col_data, u32))
                         },
                         ColumnData::NullableUInt64(_) => {
-                            column_data = ColumnData::NullableUInt64(consolidate_null_column_data!(&col_data, u64));
+                            ColumnData::NullableUInt64(consolidate_null_column_data!(&col_data, u64))
                         },
                         ColumnData::NullableFloat32(_) => {
-                            column_data = ColumnData::NullableFloat32(consolidate_null_column_data!(&col_data, f32));
+                            ColumnData::NullableFloat32(consolidate_null_column_data!(&col_data, f32))
                         },
                         ColumnData::NullableFloat64(_) => {
-                            column_data = ColumnData::NullableFloat64(consolidate_null_column_data!(&col_data, f64));
+                            ColumnData::NullableFloat64(consolidate_null_column_data!(&col_data, f64))
                         },
                         ColumnData::NullableText(_) => {
-                            column_data = ColumnData::NullableText(col_data.iter().map(|x| {
+                            ColumnData::NullableText(col_data.iter().map(|x| {
                                 if x == "" {
                                     None
                                 } else {
                                     Some(x.clone())
                                 }
-                            }).collect());
+                            }).collect())
                         }
                         _ => {
-                            column_data = ColumnData::Text(col_data.clone());
+                            ColumnData::Text(col_data.clone())
                         }
-                    }
+                    };
 
                     final_columns.push(Column {
                         name: "placeholder".to_string(),


### PR DESCRIPTION
Adds support for a new "exclude" param like this: `exclude=Subnat+Geography:48,49;Trade+Flow:1`. 

Excluding multiple levels is also supported, as long as they are separated by a `;` as in the example above. Since this is the logic layer, unique level names are expected.